### PR TITLE
Fix code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -30,9 +30,10 @@ namespace UnsecureApp.Controllers
             {
                 SqlCommand sqlCommand = new SqlCommand()
                 {
-                    CommandText = "SELECT ProductId FROM Products WHERE ProductName = '" + productName + "'",
+                    CommandText = "SELECT ProductId FROM Products WHERE ProductName = @productName",
                     CommandType = CommandType.Text,
                 };
+                sqlCommand.Parameters.AddWithValue("@productName", productName);
 
                 SqlDataReader reader = sqlCommand.ExecuteReader();
                 return reader.GetInt32(0); 


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHASge/security/code-scanning/2](https://github.com/geovanams/GHASge/security/code-scanning/2)

To fix the SQL injection vulnerability, we should use parameterized queries instead of string concatenation. This involves using `SqlCommand` with parameters to safely include user input in the SQL query. This approach ensures that any special characters in the user input are properly escaped, preventing SQL injection attacks.

**Steps to fix:**
1. Modify the SQL query to use a parameter placeholder (`@productName`) instead of directly concatenating the user input.
2. Add the `productName` parameter to the `SqlCommand` object and set its value to the user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
